### PR TITLE
“LAB” → “Lab”

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Usage: rio hist [OPTIONS] SRC_PATH REF_PATH DST_PATH
   Color correction by histogram matching
 
 Options:
-  -c, --color-space [RGB|LCH|LAB|LUV|XYZ]
+  -c, --color-space [RGB|LCH|Lab|LUV|XYZ]
                                   Colorspace
   -b, --bands TEXT                comma-separated list of bands to match
                                   (default 1,2,3)

--- a/rio_hist/scripts/cli.py
+++ b/rio_hist/scripts/cli.py
@@ -9,7 +9,7 @@ logger = logging.getLogger('rio_hist')
 
 @click.command('hist')
 @click.option('--color-space', '-c', default="RGB",
-              type=click.Choice(['RGB', 'LCH', 'LAB', 'LUV', 'XYZ']),
+              type=click.Choice(['RGB', 'LCH', 'Lab', 'LUV', 'XYZ']),
               help="Colorspace")
 @click.option('--bands', '-b', default="1,2,3",
               help="comma-separated list of bands to match (default 1,2,3)")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ def test_hist_cli_lab_colorspace(tmpdir):
     output = str(tmpdir.join('matched.tif'))
     runner = CliRunner()
     result = runner.invoke(
-        hist, ['-c', 'LAB', '-b', '1,2,3',
+        hist, ['-c', 'Lab', '-b', '1,2,3',
                'tests/data/source1.tif',
                'tests/data/reference1.tif',
                output])


### PR DESCRIPTION
The colorspace is called [Lab](https://en.wikipedia.org/wiki/Lab_color_space), sic, and spelling it LAB is likely to trip up people who are familiar with it.

Because [the colorspace string is downcased](https://github.com/mapbox/rio-hist/blob/master/rio_hist/utils.py#L52) internally, this is entirely cosmetic.