### PR TITLE
partial histogram matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - "pip install -e .[test]"
   - "pip install -e .[plot]"
 script:
-  - py.test --cov rio_color --cov-report term-missing
+  - py.test --cov rio_hist --cov-report term-missing
 after_success:
   - coveralls
 

--- a/README.md
+++ b/README.md
@@ -28,17 +28,22 @@ also allows us to see some diagnostic plots to inspect the results and the cumul
 ## CLI docs
 
 ```
+$ rio hist --help
 Usage: rio hist [OPTIONS] SRC_PATH REF_PATH DST_PATH
 
   Color correction by histogram matching
 
 Options:
-  -c, --color-space [RGB|LCH|Lab|LUV|XYZ]
+  -c, --color-space [RGB|LCH|LAB|Lab|LUV|XYZ]
                                   Colorspace
   -b, --bands TEXT                comma-separated list of bands to match
                                   (default 1,2,3)
+  -m, --match-proportion FLOAT    Interpolate values between source and
+                                  reference histogram. 1.0 (default) is full
+                                  match, 0.0 is no match
   --plot                          create a <basename>_plot.png with diagnostic
                                   plots
+  -v, --verbose
   --co NAME=VALUE                 Driver specific creation options.See the
                                   documentation for the selected output driver
                                   for more information.
@@ -50,5 +55,3 @@ Options:
 `rio_hist.match.histogram_match` is the main entry point and operates on a single band.
 
 `rio_hist.utils` has some interesting functions that may be useful in other contexts.
-
-

--- a/rio_hist/__init__.py
+++ b/rio_hist/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/rio_hist/match.py
+++ b/rio_hist/match.py
@@ -69,10 +69,10 @@ def histogram_match(source, reference, match_proportion=1.0):
     logger.debug("create target array from interpolated values by index")
     target = interp_r_values[s_idx]
 
-    # linear interpolation b/t target and source
+    # interpolation b/t target and source
     # 1.0 = full histogram match
     # 0.0 = no change
-    if match_proportion < 1:
+    if match_proportion is not None and match_proportion != 1:
         diff = source - target
         target = source - (diff * match_proportion)
 

--- a/rio_hist/match.py
+++ b/rio_hist/match.py
@@ -10,7 +10,7 @@ from .utils import cs_forward, cs_backward, read_mask
 logger = logging.getLogger(__name__)
 
 
-def histogram_match(source, reference):
+def histogram_match(source, reference, match_proportion=1.0):
     """
     Adjust the values of a source array
     so that its histogram matches that of a reference array
@@ -19,6 +19,7 @@ def histogram_match(source, reference):
     -----------
         source: np.ndarray
         reference: np.ndarray
+        match_proportion: float, range 0..1
 
     Returns:
     -----------
@@ -68,6 +69,13 @@ def histogram_match(source, reference):
     logger.debug("create target array from interpolated values by index")
     target = interp_r_values[s_idx]
 
+    # linear interpolation b/t target and source
+    # 1.0 = full histogram match
+    # 0.0 = no change
+    if match_proportion < 1:
+        diff = source - target
+        target = source - (diff * match_proportion)
+
     if np.ma.is_masked(source):
         logger.debug("source is masked, remask those pixels by position index")
         target = np.ma.masked_where(s_idx == mask_index[0], target)
@@ -88,7 +96,7 @@ def calculate_mask(src, arr):
     return mask, fill
 
 
-def hist_match_worker(src_path, ref_path, dst_path,
+def hist_match_worker(src_path, ref_path, dst_path, match_proportion,
                       creation_options, bands, color_space, plot):
     """Match histogram of src to ref, outputing to dst
     optionally output a plot to <dst>_plot.png
@@ -132,7 +140,7 @@ def hist_match_worker(src_path, ref_path, dst_path,
             ref_band.mask = ref_mask
             ref_band.fill_value = ref_fill
 
-        target[b] = histogram_match(src_band, ref_band)
+        target[b] = histogram_match(src_band, ref_band, match_proportion)
 
     target_rgb = cs_backward(target, color_space)
 

--- a/rio_hist/scripts/cli.py
+++ b/rio_hist/scripts/cli.py
@@ -13,6 +13,10 @@ logger = logging.getLogger('rio_hist')
               help="Colorspace")
 @click.option('--bands', '-b', default="1,2,3",
               help="comma-separated list of bands to match (default 1,2,3)")
+@click.option('--match-proportion', '-m', default=1.0, type=float,
+              help="Linearly interpolate values to a proportion between"
+                   "source and target values. 1.0 is full match"
+                   "0.0 is no match")
 @click.option('--plot', is_flag=True, default=False,
               help="create a <basename>_plot.png with diagnostic plots")
 @click.option('--verbose', '-v', is_flag=True, default=False)
@@ -21,12 +25,12 @@ logger = logging.getLogger('rio_hist')
 @click.argument('dst_path', type=click.Path(exists=False))
 @click.pass_context
 @creation_options
-def hist(ctx, src_path, ref_path, dst_path,
+def hist(ctx, src_path, ref_path, dst_path, match_proportion,
          verbose, creation_options, bands, color_space, plot):
     """Color correction by histogram matching
     """
     if verbose:
         logger.setLevel(logging.DEBUG)
 
-    hist_match_worker(src_path, ref_path, dst_path,
+    hist_match_worker(src_path, ref_path, dst_path, match_proportion,
                       creation_options, bands, color_space, plot)

--- a/rio_hist/scripts/cli.py
+++ b/rio_hist/scripts/cli.py
@@ -7,6 +7,12 @@ from rio_hist.match import hist_match_worker
 logger = logging.getLogger('rio_hist')
 
 
+def validate_proportion(ctx, param, value):
+    if value < 0 or value > 1:
+        raise click.BadParameter('must be between 0 and 1')
+    return float(value)
+
+
 @click.command('hist')
 @click.option('--color-space', '-c', default="RGB",
               type=click.Choice(['RGB', 'LCH', 'LAB', 'Lab', 'LUV', 'XYZ']),
@@ -14,9 +20,9 @@ logger = logging.getLogger('rio_hist')
 @click.option('--bands', '-b', default="1,2,3",
               help="comma-separated list of bands to match (default 1,2,3)")
 @click.option('--match-proportion', '-m', default=1.0, type=float,
-              help="Linearly interpolate values to a proportion between"
-                   "source and target values. 1.0 is full match"
-                   "0.0 is no match")
+              callback=validate_proportion,
+              help="Interpolate values between source and reference histogram. "
+                   "1.0 (default) is full match, 0.0 is no match")
 @click.option('--plot', is_flag=True, default=False,
               help="create a <basename>_plot.png with diagnostic plots")
 @click.option('--verbose', '-v', is_flag=True, default=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,12 @@
 import os
 
+import click
 from click.testing import CliRunner
 import pytest
 import rasterio
+import numpy as np
 
-from rio_hist.scripts.cli import hist
+from rio_hist.scripts.cli import hist, validate_proportion
 
 
 def test_hist_cli(tmpdir):
@@ -83,3 +85,29 @@ def test_hist_cli_plot(tmpdir):
     assert result.exit_code == 0
     with rasterio.open(output) as out:
         assert out.count == 4  # RGBA
+
+def test_partial(tmpdir):
+    output = str(tmpdir.join('matched.tif'))
+    runner = CliRunner()
+    result = runner.invoke(
+        hist, ['-m', '0.5',
+               'tests/data/source1.tif',
+               'tests/data/reference1.tif',
+               output])
+    assert result.exit_code == 0
+    with rasterio.open(output) as match, \
+            rasterio.open('tests/data/source1.tif') as src, \
+            rasterio.open('tests/data/reference1.tif') as ref:
+        m = match.read(2)
+        s = src.read(2)
+        r = ((ref.read(2) / 65365) * 256).astype('uint8')
+        assert np.median(s) > np.median(m)  # darker than the source
+        assert np.median(r) < np.median(m)  # but not quite as dark as the reference
+
+
+def test_validate_proportion():
+    assert validate_proportion(None, None, 0) == 0.0
+    assert validate_proportion(None, None, 0.5) == 0.5
+    assert validate_proportion(None, None, 1) == 1.0
+    with pytest.raises(click.BadParameter):
+        assert validate_proportion(None, None, 9000)


### PR DESCRIPTION
Specifying `--match-proportion 1.0` will do a full histogram match (the default)

Specifying `--match-proportion 0.0` will effectively not change anything.

For every value in between, it moves the source closer to the reference by linear interpolation on the cumulative distribution.

![out](https://cloud.githubusercontent.com/assets/1151287/19971536/b285dcc4-a1b5-11e6-9ef9-5e5f4022c967.gif)

Resolves #8 

todo
* [x] try with some other scenes; i'm sure there are edge cases that don't work well.
* [x] try with other colorspaces. only RGB so far.
* [ ] unit and integration tests

cc @celoyd @virginiayung 