### PR TITLE
added support for input images with float datatype

### DIFF
--- a/rio_hist/utils.py
+++ b/rio_hist/utils.py
@@ -26,7 +26,8 @@ def reshape_as_raster(arr):
 def cs_forward(arr, cs='rgb'):
     """ RGB (any dtype) to whatevs
     """
-    arrnorm_raw = arr.astype('float64') / np.iinfo(arr.dtype).max
+    info = np.finfo if 'f' in arr.dtype.str else np.iinfo
+    arrnorm_raw = arr.astype('float64') / info(arr.dtype).max
     arrnorm = arrnorm_raw[0:3]
     cs = cs.lower()
     if cs == 'rgb':


### PR DESCRIPTION
usage of **np.iinfo** forces the user to use only arrays (images) with integer data type in cs_forward function in rio_hist/utils.py. So, a small change was added to the same function which will use np.finfo if the input arr is float and use np.iinfo otherwise